### PR TITLE
feat: add http status errors

### DIFF
--- a/error/status.go
+++ b/error/status.go
@@ -1,0 +1,40 @@
+package error
+
+import "net/http"
+
+type (
+	// HandlerError represents an error raised inside a HTTP handler
+	HandlerError struct {
+		StatusCode int
+		Message    string
+		Err        error
+	}
+)
+
+func NewError(statusCode int, message string, err error) *HandlerError {
+	return &HandlerError{
+		StatusCode: statusCode,
+		Message:    message,
+		Err:        err,
+	}
+}
+
+func BadRequest(message string, err error) *HandlerError {
+	return NewError(http.StatusBadRequest, message, err)
+}
+
+func NotFound(message string, err error) *HandlerError {
+	return NewError(http.StatusNotFound, message, err)
+}
+
+func InternalServerError(message string, err error) *HandlerError {
+	return NewError(http.StatusInternalServerError, message, err)
+}
+
+func Unauthorized(message string, err error) *HandlerError {
+	return NewError(http.StatusUnauthorized, message, err)
+}
+
+func Forbidden(message string, err error) *HandlerError {
+	return NewError(http.StatusForbidden, message, err)
+}


### PR DESCRIPTION
[DTD-92]

this PR add functions to create HandlerError:
- `NewError` - general function for any status code
- specific for status code: `BadRequest`, `NotFound`, `InternalServerError`, `Unauthorized`, `Forbidden`

it also adds the option to create an handler error without an error object, and only a message. in this case it will create an error object from the message

[DTD-92]: https://portainer.atlassian.net/browse/DTD-92?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ