### PR TITLE
feat: log the correct caller [EE-5198]

### DIFF
--- a/error/error.go
+++ b/error/error.go
@@ -31,7 +31,7 @@ func writeErrorResponse(rw http.ResponseWriter, err *HandlerError) {
 		err.Err = errors.New(err.Message)
 	}
 
-	log.Debug().Err(err.Err).Int("status_code", err.StatusCode).Str("msg", err.Message).Msg("HTTP error")
+	log.Debug().CallerSkipFrame(2).Err(err.Err).Int("status_code", err.StatusCode).Str("msg", err.Message).Msg("HTTP error")
 
 	rw.Header().Set("Content-Type", "application/json")
 	rw.WriteHeader(err.StatusCode)


### PR DESCRIPTION
Something that's bugged me is the caller of the error isn't the correct one when logging an error.
This fixes that.

Fixing as part of [EE-5198]

[EE-5198]: https://portainer.atlassian.net/browse/EE-5198?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ